### PR TITLE
Parse Postgres's LOCK TABLE statement

### DIFF
--- a/src/ast/spans.rs
+++ b/src/ast/spans.rs
@@ -478,6 +478,7 @@ impl Spanned for Statement {
             Statement::CreateType { .. } => Span::empty(),
             Statement::Pragma { .. } => Span::empty(),
             Statement::LockTables { .. } => Span::empty(),
+            Statement::LockTablesPG { .. } => Span::empty(),
             Statement::UnlockTables => Span::empty(),
             Statement::Unload { .. } => Span::empty(),
             Statement::OptimizeTable { .. } => Span::empty(),

--- a/tests/sqlparser_postgres.rs
+++ b/tests/sqlparser_postgres.rs
@@ -5200,3 +5200,30 @@ fn parse_bitstring_literal() {
 fn parse_select_without_projection() {
     pg_and_generic().verified_stmt("SELECT FROM users");
 }
+
+#[test]
+fn parse_lock_table() {
+    pg().verified_stmt("LOCK customers");
+    pg().verified_stmt("LOCK TABLE customers");
+    pg().verified_stmt("LOCK TABLE ONLY customers");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN ACCESS SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN ROW SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN ROW EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN SHARE UPDATE EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN SHARE ROW EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers IN ACCESS EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK customers, orders");
+    pg().verified_stmt("LOCK TABLE customers, orders");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ACCESS SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ROW SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ROW EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN SHARE UPDATE EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN SHARE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN SHARE ROW EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ACCESS EXCLUSIVE MODE");
+    pg().verified_stmt("LOCK TABLE ONLY customers, orders IN ACCESS SHARE MODE NOWAIT");
+}


### PR DESCRIPTION
See: https://www.postgresql.org/docs/current/sql-lock.html

PG's full syntax for this statement is supported:

```
LOCK [ TABLE ] [ ONLY ] name [ * ] [, ...] [ IN lockmode MODE ] [ NOWAIT ]

where lockmode is one of:

    ACCESS SHARE | ROW SHARE | ROW EXCLUSIVE | SHARE UPDATE EXCLUSIVE
    | SHARE | SHARE ROW EXCLUSIVE | EXCLUSIVE | ACCESS EXCLUSIVE
```

It is implemented to not intefere with the roughly equivalent (but different) syntax in MySQL, by using a new Statement variant.